### PR TITLE
Add show showArgsVar

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,16 @@ Executing ${source}
 
 `;
 
+let showArgsVar;
+
 const printable = (obj, delimiter = ", ") =>
   Object.entries(obj)
     .map(([k, v]) => `${k}: '${v}'`)
     .join(delimiter);
 
-module.exports = function(eventEmitter) {
+module.exports = function (eventEmitter, showArgs = false) {
+  showArgsVar = showArgs;
+
   eventEmitter.on("script/start", logScriptStart);
   eventEmitter.on("step/start", logStepStart);
 };
@@ -29,10 +33,10 @@ const logScriptStart = script => {
     console.log("SCRIPT:", JSON.stringify(script, null, 2));
 };
 
-var logStepStart = function(step, context) {
+const logStepStart = function (step, context) {
   const fullName = step.meta["Full name"].cyan;
   const row = colors.yellow(`row ${step.meta.Row}`);
-  if (Object.keys(step.arguments).length) {
+  if (Object.keys(step.arguments).length && showArgsVar) {
     console.log(`Executing step ${fullName} on ${row} with arguments:`);
     const opts = { noRefs: true, noCompatMode: true };
     console.log(colors.grey(yaml.safeDump(step.arguments)));

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const printable = (obj, delimiter = ", ") =>
     .map(([k, v]) => `${k}: '${v}'`)
     .join(delimiter);
 
-module.exports = function (eventEmitter, showArgs = false) {
+module.exports = function (eventEmitter, showArgs = true) {
   showArgsVar = showArgs;
 
   eventEmitter.on("script/start", logScriptStart);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,30 +5,30 @@
   "requires": true,
   "dependencies": {
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Gresyarch BV",
   "license": "ISC",
   "dependencies": {
-    "colors": "^1.1.2",
-    "js-yaml": "^3.10.0"
+    "colors": "^1.4.0",
+    "js-yaml": "^3.13.1"
   }
 }


### PR DESCRIPTION
While running the script in production you want to hide the args because sometimes they expose som rendered sensitive data like credentials. You can set `showArgsVar` when calling the library.
```javascript
const testx = require('testx');
const logger = require('@testx/default-logger');

logger(testx.events, false); // default value is true
```